### PR TITLE
Fix API endpoint for period search

### DIFF
--- a/public/api.js
+++ b/public/api.js
@@ -31,12 +31,9 @@ const api = {
   searchPeriod: async (params) => {
     console.log("API: Iniciando busca por período com parâmetros:", params);
     try {
-      const response = await fetch('/api/period', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify(params)
+      const query = new URLSearchParams(params).toString();
+      const response = await fetch(`/api/best-prices?${query}`, {
+        method: 'GET'
       });
       
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- connect frontend period search to `/api/best-prices` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683cadc4d2b883219622d3063313888e